### PR TITLE
All trips connected to purchase logic

### DIFF
--- a/qt/app/dbmanager.cpp
+++ b/qt/app/dbmanager.cpp
@@ -81,7 +81,7 @@ void DBManager::ImportCities(QWidget *parent)
 //	QTime start = QTime::currentTime();
 
 	if (!file.open(QFile::ReadOnly)) {
-			qDebug() << "DBManager::ImportCities() : error openning the file";
+            qDebug() << "DBManager::ImportCities() : error opening the file";
 	} else {
 		qDebug() << "file opened";
 		QTextStream ss(&file);

--- a/qt/app/mainwindow.cpp
+++ b/qt/app/mainwindow.cpp
@@ -86,8 +86,13 @@ void MainWindow::on_pushButton_home_custom_clicked()
     ui->label_custom_otherCities->hide();
     ui->comboBox_custom_otherCities->hide();
     ui->pushButton_custom_add->hide();
+
+    // Reset fields/objects
+    customTripCities.clear();
     ui->label_custom_distance->clear();
+    customTripComboBoxCities.clear();
     ui->comboBox_custom_otherCities->clear();
+    ui->comboBox_custom_startingCity->clear();
 
     // Reset table
     QSqlQueryModel* reset = new QSqlQueryModel;
@@ -104,15 +109,9 @@ void MainWindow::on_pushButton_home_custom_clicked()
     // Set combobox index to 0
     ui->comboBox_custom_startingCity->setCurrentIndex(0);
 
-    // Clear custom trip cities list
-    customTripCities.clear();
-
-    // Populate cities dropdown only one time
-    if(ui->comboBox_custom_startingCity->count() == 0)
-    {
-        DBManager::instance()->GetCities(customTripComboBoxCities);
-        ui->comboBox_custom_startingCity->addItems(customTripComboBoxCities);
-    }
+    // Populate cities dropdown
+    DBManager::instance()->GetCities(customTripComboBoxCities);
+    ui->comboBox_custom_startingCity->addItems(customTripComboBoxCities);
 
     // Grey out 'finalize trip'
     ui->pushButton_custom_finalize->setDisabled(true);
@@ -189,6 +188,22 @@ void MainWindow::on_pushButton_paris_back_clicked()
 void MainWindow::on_pushButton_paris_continue_clicked()
 {
     ui->stackedWidget_pages->setCurrentIndex(PURCHASE);
+
+    // Create shopping list
+    DBManager::instance()->CreateShoppingList(cities);
+
+    // Initialize purchase table to blank
+    TableManager::instance()->InitializePurchaseTable(ui->tableWidget_purchase_pos,
+                                                      TableManager::instance()->PURCHASE_TABLE_COL_COUNT,
+                                                      TableManager::instance()->purchaseTableColNames);
+    // Populate purchase table
+    TableManager::instance()->PopulatePurchaseTable(ui->tableWidget_purchase_pos, cities);
+
+    // Insert spinbox column
+    TableManager::instance()->InsertSpinBoxCol(ui->tableWidget_purchase_pos,
+                                               TableManager::instance()->PURCHASE_SPINBOX_MIN,
+                                               TableManager::instance()->PURCHASE_SPINBOX_MAX,
+                                               TableManager::instance()->P_QTY);
 }
 
 /*----CUSTOM-----*/
@@ -200,6 +215,22 @@ void MainWindow::on_pushButton_custom_back_clicked()
 void MainWindow::on_pushButton_custom_continue_clicked()
 {
     ui->stackedWidget_pages->setCurrentIndex(PURCHASE);
+
+    // Create shopping list
+    DBManager::instance()->CreateShoppingList(cities);
+
+    // Initialize purchase table to blank
+    TableManager::instance()->InitializePurchaseTable(ui->tableWidget_purchase_pos,
+                                                      TableManager::instance()->PURCHASE_TABLE_COL_COUNT,
+                                                      TableManager::instance()->purchaseTableColNames);
+    // Populate purchase table
+    TableManager::instance()->PopulatePurchaseTable(ui->tableWidget_purchase_pos, cities);
+
+    // Insert spinbox column
+    TableManager::instance()->InsertSpinBoxCol(ui->tableWidget_purchase_pos,
+                                               TableManager::instance()->PURCHASE_SPINBOX_MIN,
+                                               TableManager::instance()->PURCHASE_SPINBOX_MAX,
+                                               TableManager::instance()->P_QTY);
 }
 
 void MainWindow::on_comboBox_custom_startingCity_activated(int index)

--- a/qt/app/mainwindow.cpp
+++ b/qt/app/mainwindow.cpp
@@ -126,6 +126,7 @@ void MainWindow::on_pushButton_home_exit_clicked()
 void MainWindow::on_pushButton_berlin_back_clicked()
 {
     ui->stackedWidget_pages->setCurrentIndex(HOME);
+    DestroyCities();
 }
 
 void MainWindow::on_pushButton_berin_continue_clicked()
@@ -183,6 +184,7 @@ void MainWindow::on_spinBox_paris_select_valueChanged(int citiesToVisit)
 void MainWindow::on_pushButton_paris_back_clicked()
 {
     ui->stackedWidget_pages->setCurrentIndex(HOME);
+    DestroyCities();
 }
 
 void MainWindow::on_pushButton_paris_continue_clicked()
@@ -210,6 +212,7 @@ void MainWindow::on_pushButton_paris_continue_clicked()
 void MainWindow::on_pushButton_custom_back_clicked()
 {
     ui->stackedWidget_pages->setCurrentIndex(HOME);
+    DestroyCities();
 }
 
 void MainWindow::on_pushButton_custom_continue_clicked()
@@ -269,6 +272,7 @@ void MainWindow::on_comboBox_custom_startingCity_activated(int index)
 void MainWindow::on_pushButton_purchase_back_clicked()
 {
     ui->stackedWidget_pages->setCurrentIndex(HOME);
+    DestroyCities();
 }
 
 void MainWindow::on_pushButton_purchase_continue_clicked()
@@ -287,6 +291,7 @@ void MainWindow::on_pushButton_purchase_continue_clicked()
 void MainWindow::on_pushButton_receipt_back_clicked()
 {
     ui->stackedWidget_pages->setCurrentIndex(HOME);
+    DestroyCities();
 }
 
 /*----ADMIN----*/

--- a/qt/app/mainwindow.cpp
+++ b/qt/app/mainwindow.cpp
@@ -75,8 +75,20 @@ void MainWindow::on_pushButton_home_berlin_clicked()
 
 void MainWindow::on_pushButton_home_paris_clicked()
 {
+    City temp; // City object to populate initial cities list
+
     ui->stackedWidget_pages->setCurrentIndex(PARIS);
     ui->spinBox_paris_select->setValue(1);
+
+    // Delete existing cities list
+    DestroyCities();
+
+    // Populate initial two cities
+    temp.SetName("Paris");
+    cities->push_back(temp);
+    temp.SetName("Brussels");
+    cities->push_back(temp);
+
 }
 
 void MainWindow::on_pushButton_home_custom_clicked()
@@ -86,6 +98,9 @@ void MainWindow::on_pushButton_home_custom_clicked()
     ui->label_custom_otherCities->hide();
     ui->comboBox_custom_otherCities->hide();
     ui->pushButton_custom_add->hide();
+
+    // Delete existing cities list
+    DestroyCities();
 
     // Reset fields/objects
     customTripCities.clear();
@@ -161,13 +176,28 @@ void MainWindow::on_spinBox_paris_select_valueChanged(int citiesToVisit)
     unsorted.removeAll("Paris");
     unsorted.push_front("Paris");
     algorithm::sort(unsorted, sorted);
+    City temp; // temp object used to populate purchase page
 
-    ui->spinBox_paris_select->setMaximum(sorted.length() - 1); // fills the spinbox with max number of cities to visit
+    // Populate spinbox
+    ui->spinBox_paris_select->setMaximum(sorted.length() - 1);
 
-    for (int i = 0; i < citiesToVisit + 1; i++) // fills trip list with sorted list
+    // Fill trip list with sorted list
+    for (int i = 0; i < citiesToVisit + 1; i++)
     {
         trip.push_back(sorted.front());
         sorted.pop_front();
+    }
+
+    // If spinbox value is decreased, remove city from purchase cities list
+    if(ui->spinBox_paris_select->value() < parisSpinBoxPreviousVal && cities->size() > 0)
+    {
+        cities->pop_back();
+    }
+    else // If spinbox value is increased, add city to purchase cities list
+    {
+        // Add subsequent cities to purchase page object
+        temp.SetName(trip.back());
+        cities->push_back(temp);
     }
 
     TableManager::instance()->PopulateTripTable(ui->tableView_paris_cities, trip);
@@ -179,6 +209,8 @@ void MainWindow::on_spinBox_paris_select_valueChanged(int citiesToVisit)
 
     ui->label_paris_total_distance->setText("Total Distance(km): " + QString::number(total));
     ui->label_paris_total_distance->adjustSize();
+
+    parisSpinBoxPreviousVal = ui->spinBox_paris_select->value();
 }
 
 void MainWindow::on_pushButton_paris_back_clicked()
@@ -412,7 +444,6 @@ void ClearFields()
 {
 
 }
-
 
 // Create receipt to print on receipt page
 void MainWindow::CreateReceipt(QVector<City>* cities)

--- a/qt/app/mainwindow.h
+++ b/qt/app/mainwindow.h
@@ -109,5 +109,7 @@ private:
     QStringList customTripCities;
     QStringList customTripComboBoxCities;
 
+    int parisSpinBoxPreviousVal = 0;
+
 };
 #endif // MAINWINDOW_H


### PR DESCRIPTION
Also bugfix for custom trip dropdown.

1. Check purchase page linking for Paris Trip
2. Check purchase page linking for Custom Trip

3. Check dropdown repopulation in Custom Trip
-a. Make custom trip, proceed to end. Attempt another custom trip. Notice cities have repopulated
-b. Import new cities from file. Attempt to plan custom trips. Notice cities are present.
-c. Repeat 3a after importing new cities. Cities should repopulate fine.
